### PR TITLE
Kernel upgrade

### DIFF
--- a/packer/balanced-client.json
+++ b/packer/balanced-client.json
@@ -17,10 +17,11 @@
             "source_ami": "ami-0b9c9f62",
             "instance_type": "m3.xlarge",
             "ssh_username": "ubuntu",
-            "ami_name": "Balanced Chef-Client Ubuntu 12.04 (EBS store) {{isotime | clean_ami_name}}",
+            "ami_name": "Balanced Chef-Client Ubuntu 12.04 (EBS store, 3.8.0 Linux Kernel) {{isotime | clean_ami_name}}",
             "tags": {
                 "OS_Version": "ubuntu",
-                "Release": "12.04"
+                "Release": "12.04",
+                "Linux_Kernel": "3.8.0"
             }
         }
     ],

--- a/packer/balanced-client.json
+++ b/packer/balanced-client.json
@@ -70,6 +70,16 @@
         {
             "type": "shell",
             "script": "init.sh"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "apt-get -y update",
+                "apt-get -y install linux-image-generic-lts-raring",
+                "apt-get -y install linux-headers-generic-lts-raring",
+                "reboot",
+                "sleep 60"
+            ]
         }
     ]
 }


### PR DESCRIPTION
If we're going to run docker, we will need the kernel to be upgraded to 3.8.0

ref: http://docs.docker.io.s3-website-us-west-2.amazonaws.com/installation/ubuntulinux/
